### PR TITLE
updating the demo inline with version 1.0.0 (latest) of the extension

### DIFF
--- a/src/test/java/org/concordion/ext/specification/OverWritingDefaultPropertiesTest.java
+++ b/src/test/java/org/concordion/ext/specification/OverWritingDefaultPropertiesTest.java
@@ -1,6 +1,7 @@
 package org.concordion.ext.specification;
 
 import org.concordion.api.extension.Extension;
+import org.concordion.ext.statusinfo.StatusInfo;
 import org.concordion.ext.statusinfo.StatusInfoExtension;
 import org.concordion.integration.junit4.ConcordionRunner;
 import org.junit.runner.RunWith;
@@ -12,12 +13,14 @@ public class OverWritingDefaultPropertiesTest {
     private int totalAmount = 0;
     private int totalSpent = 0;
 
+    private StatusInfo statusInfoConfig = new StatusInfo()
+            .withMessageSize("h1")
+            .withTitleTextPrefix("New Note")
+            .withReasonPrefixMessage("New Reason")
+            .withStyle("font-weight: normal; text-decoration: none; color: #FFFF00;");
+
     @Extension
-    StatusInfoExtension statusInfo = new StatusInfoExtension()
-            .setHeaderElementSize("h1")
-            .setNoteMessage("New Note")
-            .setReasonPrefixMessage("New Reason")
-            .setStyle("font-weight: normal; text-decoration: none; color: #FFFF00;");
+    StatusInfoExtension statusInfo = new StatusInfoExtension().setStatusInfo(statusInfoConfig);
 
     public void amountTotal(String amount) {
         totalAmount = Integer.parseInt(amount.trim());


### PR DESCRIPTION
bringing the demo in line with version 1.0.0 of the extension
- minor fix with statusInfo builder for showing an example of how to modify the default display properties of the extension